### PR TITLE
Edit SceneSat endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 
         async function scrape() {
             try {
-                let response = await fetch("https://scenesat.com/playing");
+                let response = await fetch("https://scenesat.com/playdetails");
                 let data = await response.json();
 
                 title_label.innerText = data.title;


### PR DESCRIPTION
SceneSat webplayer used "https://scenesat.com/playdetails" as endpoint.
This endpoint is backwards compatible and contains additional fields like
* track_type
* artwork

I couldn't find any specific announcement, I assume "https://scenesat.com/playdetails" is newer, and "https://scenesat.com/playing" will be retired eventually.